### PR TITLE
fix: decrement total_funded when bonuses paid

### DIFF
--- a/program/programs/proof-of-wake/src/lib.rs
+++ b/program/programs/proof-of-wake/src/lib.rs
@@ -160,6 +160,10 @@ pub mod proof_of_wake {
             if actual_bonus > 0 {
                 **ctx.accounts.treasury.to_account_info().try_borrow_mut_lamports()? -= actual_bonus;
                 **ctx.accounts.authority.to_account_info().try_borrow_mut_lamports()? += actual_bonus;
+                
+                // Update treasury accounting
+                let treasury = &mut ctx.accounts.treasury;
+                treasury.total_funded = treasury.total_funded.saturating_sub(actual_bonus);
             }
         }
 


### PR DESCRIPTION
Fixes #13

## Problem
`total_funded` wasn't decremented when bonuses were paid out, causing accounting drift over time.

## Solution
- Decrement `treasury.total_funded` by `actual_bonus` after payout
- Use `saturating_sub` to handle edge cases gracefully

## Changes
- 4 lines added to `complete_day` in the bonus payout block